### PR TITLE
Prevent re-rendering when using checkConnectionInterval

### DIFF
--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { NetInfo, Platform } from 'react-native';
 import hoistStatics from 'hoist-non-react-statics';
@@ -43,7 +43,7 @@ const withNetworkConnectivity = (
     throw new Error('you should pass a string as pingServerUrl parameter');
   }
 
-  class EnhancedComponent extends Component<void, void, State> {
+  class EnhancedComponent extends PureComponent<void, void, State> {
     static displayName = `withNetworkConnectivity(${WrappedComponent.displayName})`;
 
     static contextTypes = {


### PR DESCRIPTION
When using `checkConnectionInterval` in `withNetworkConnectivity`, it pings the `pingServerUrl` every interval.
It also re-rendering every time even `isConnected` does not change at all.

To prevent re-rendering, change `React.Component` to `React.PureComponent` solved this issue.