### PR TITLE
Free interval variable after clearInterval()

### DIFF
--- a/src/checkConnectivityInterval.js
+++ b/src/checkConnectivityInterval.js
@@ -14,5 +14,6 @@ export const setupConnectivityCheckInterval = (
 export const clearConnectivityCheckInterval = () => {
   if (interval) {
     clearInterval(interval);
+    interval = null;
   }
 };


### PR DESCRIPTION
Once interval is cleared, it cannot be created again. Useful when hot reloading.