### PR TITLE
default pingServerUrl  (http) protocol converted to (https) protocol

### DIFF
--- a/src/sagas.js
+++ b/src/sagas.js
@@ -147,7 +147,7 @@ function* handleConnectivityChange(
 export default function* networkEventsListenerSaga(
   {
     timeout = 3000,
-    pingServerUrl = 'http://www.google.com/',
+    pingServerUrl = 'https://www.google.com/',
     withExtraHeadRequest = true,
     checkConnectionInterval = 0,
   }: Arguments = {},


### PR DESCRIPTION
I wanted to try this library to see if it works as explained or not, but I could not get it working (it was always showing isConnected = false), but after a while I realized that the pingServerUrl is using unsecured protocol (http) which IOS does not allow (it can allow with setting unsecured configurations in whole), but it is always better to be secured and use https protocol as default.  

At the mean time the fix will avoid the confusion and frustration for new users who just want to use the default config parameters of the library.

Closes https://github.com/rgommezz/react-native-offline/issues/103