### PR TITLE
Similar action comparison fixes for usage with thunks

### DIFF
--- a/src/createNetworkMiddleware.js
+++ b/src/createNetworkMiddleware.js
@@ -7,6 +7,7 @@ import {
   dismissActionsFromQueue,
 } from './actionCreators';
 import type { NetworkState } from './types';
+import similarActionCheck from "./similarActionCheck";
 
 type MiddlewareAPI<S> = {
   dispatch: (action: any) => void,
@@ -48,7 +49,7 @@ function createNetworkMiddleware(
         return next(fetchOfflineMode(action)); // Offline, preventing the original action from being dispatched. Dispatching an internal action instead.
       }
       const actionQueued = actionQueue.length > 0
-        ? find(actionQueue, (a: *) => isEqual(a, action))
+        ? similarActionCheck(action, actionQueue)
         : null;
       if (actionQueued) {
         // Back online and the action that was queued is about to be dispatched.

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -8,6 +8,7 @@ import type {
   FluxActionForRemoval,
   NetworkState,
 } from './types';
+import similarActionCheck from './similarActionCheck';
 
 export const initialState = {
   isConnected: true,
@@ -33,8 +34,9 @@ function handleOfflineAction(
     const actionWithMetaData = typeof actionToLookUp === 'object'
       ? { ...actionToLookUp, meta }
       : actionToLookUp;
-    const similarActionQueued = find(state.actionQueue, (action: *) =>
-      isEqual(action, actionWithMetaData),
+    const similarActionQueued = similarActionCheck(
+      actionWithMetaData,
+      state.actionQueue,
     );
 
     return {
@@ -54,9 +56,7 @@ function handleRemoveActionFromQueue(
   state: NetworkState,
   action: FluxActionForRemoval,
 ): NetworkState {
-  const similarActionQueued = find(state.actionQueue, (a: *) =>
-    isEqual(action, a),
-  );
+  const similarActionQueued = similarActionCheck(action, state.actionQueue);
 
   return {
     ...state,

--- a/src/similarActionCheck.js
+++ b/src/similarActionCheck.js
@@ -10,14 +10,12 @@ import { isEqual } from 'lodash';
  * @param actionQueue
  */
 export default function similarActionCheck(
-  action: FluxActionWithPreviousIntent,
+  action: *,
   actionQueue: Array<*>,
 ) {
-  const { prevAction, prevThunk } = action.payload;
-
-  if (typeof prevAction === 'object') {
+  if (typeof action === 'object') {
     return actionQueue.find((queued: *) => isEqual(queued, action));
-  } else if (prevThunk === 'function') {
+  } else if (typeof action === 'function') {
     return actionQueue.find(
       (queued: *) => action.toString() === queued.toString(),
     );

--- a/src/similarActionCheck.js
+++ b/src/similarActionCheck.js
@@ -1,0 +1,26 @@
+/**
+ * @flow
+ */
+import { isEqual } from 'lodash';
+
+/**
+ * Finds and returns a similar thunk or action in the actionQueue.
+ * Else undefined.
+ * @param action
+ * @param actionQueue
+ */
+export default function similarActionCheck(
+  action: FluxActionWithPreviousIntent,
+  actionQueue: Array<*>,
+) {
+  const { prevAction, prevThunk } = action.payload;
+
+  if (typeof prevAction === 'object') {
+    return actionQueue.find((queued: *) => isEqual(queued, action));
+  } else if (prevThunk === 'function') {
+    return actionQueue.find(
+      (queued: *) => action.toString() === queued.toString(),
+    );
+  }
+  return undefined;
+}


### PR DESCRIPTION
A fix for #116. All action comparisons are right now being done using _.isEqual to prevent duplicate actions in the action queue. However _.isEqual does not support functions so this doesn't work for thunks. I implemented a new function `similarActionCheck` which can be used to do this instead.

I haven't written any tests yet but it's working perfectly in my project where I'm working with thunks.