### PR TITLE
fix Redux integration desynchronizing internal state

### DIFF
--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -134,8 +134,8 @@ const withNetworkConnectivity = (
             store.dispatch(action);
           });
         }
-      } 
-        
+      }
+
       this.setState({ isConnected });
     };
 

--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -134,10 +134,9 @@ const withNetworkConnectivity = (
             store.dispatch(action);
           });
         }
-      } else {
-        // Standard HOC, passing connectivity as props
-        this.setState({ isConnected });
-      }
+      } 
+        
+      this.setState({ isConnected });
     };
 
     render() {


### PR DESCRIPTION
When Redux integration is enabled by `withRedux`, `react-native-offline` only updates the Redux store but not its own state, which leads to inside/outside state inconsistencies.

This PR removes the `else` branch responsible for not updating internal state, making the library work more reliably.