### PR TITLE
Add support of custom http methods "HEAD" & "OPTIONS" (only for withNetworkConnectivity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ type Config = {
   withExtraHeadRequest?: boolean = true,
   checkConnectionInterval?: number = 0,
   checkInBackground?: boolean = false,
+  httpMethod?: string = 'HEAD',
 }
 ```
 
@@ -94,6 +95,8 @@ type Config = {
 `checkConnectionInterval`: the interval (in ms) you want to ping the server at. The default is 0, and that means it is not going to regularly check connectivity.
 
 `checkInBackground`: whether or not to check connectivity when app isn't active. Default is `false`.
+
+`httpMethod`: usage http method to check the internet-access. Supports HEAD or OPTIONS. Default is `HEAD`.
 
 ##### Usage
 ```js

--- a/src/checkInternetAccess.js
+++ b/src/checkInternetAccess.js
@@ -1,13 +1,15 @@
 /* @flow */
 import makeHttpRequest from './makeHttpRequest';
+import type { HTTPMethod } from './types';
 
 export default function checkInternetAccess(
   timeout: number = 3000,
   url: string = 'http://www.google.com/',
+  method: HTTPMethod = 'HEAD',
 ): Promise<boolean> {
   return new Promise((resolve: (value: boolean) => void) => {
     makeHttpRequest({
-      method: 'HEAD',
+      method,
       url,
       timeout,
     })

--- a/src/types.js
+++ b/src/types.js
@@ -35,3 +35,5 @@ export type NetworkState = {
   isConnected: boolean,
   actionQueue: Array<*>,
 };
+
+export type HTTPMethod = 'HEAD' | 'OPTIONS';

--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -11,6 +11,7 @@ import {
   setupConnectivityCheckInterval,
   clearConnectivityCheckInterval,
 } from './checkConnectivityInterval';
+import type { HTTPMethod } from './types';
 
 type Arguments = {
   withRedux?: boolean,
@@ -19,6 +20,7 @@ type Arguments = {
   withExtraHeadRequest?: boolean,
   checkConnectionInterval?: number,
   checkInBackground?: boolean,
+  httpMethod?: HTTPMethod,
 };
 
 type State = {
@@ -33,6 +35,7 @@ const withNetworkConnectivity = (
     withExtraHeadRequest = true,
     checkConnectionInterval = 0,
     checkInBackground = false,
+    httpMethod = 'HEAD',
   }: Arguments = {},
 ) => (WrappedComponent: ReactClass<*>) => {
   if (typeof withRedux !== 'boolean') {
@@ -108,6 +111,7 @@ const withNetworkConnectivity = (
       checkInternetAccess(
         timeout,
         pingServerUrl,
+        httpMethod,
       ).then((hasInternetAccess: boolean) => {
         this.handleConnectivityChange(hasInternetAccess);
       });


### PR DESCRIPTION
Inspired by https://github.com/rgommezz/react-native-offline/issues/74 and needed for my own project I implemented support of custom http methods _HEAD_ and _OPTIONS_ to check internet-access (only for method **withNetworkConnectivity**)

Closes #74 