### PR TITLE
Remove circular dependency in redux-saga

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "hoist-non-react-statics": "^1.2.0",
     "lodash": "^4.17.4",
-    "redux-saga": "*"
+    "redux-saga": "^0.16.1"
   },
   "jest": {
     "collectCoverage": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3976,9 +3976,9 @@ redux-mock-store@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.3.tgz#1b3ad299da91cb41ba30d68e3b6f024475fb9e1b"
 
-redux-saga@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
+redux-saga@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.1.tgz#aa43d2ac029dab57f7f522b143f7db179a9e1324"
 
 redux-thunk@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Hello,

This PR upgrade redux-saga to version 0.16.1 which fixes circular dependency.
The circular dependency is annoying with React Native 0.57 because of the yellow box warnings.

Thanks,
Julien Usson