### PR TITLE
Fix issue when using redux and checkIntervalOfflineOnly

### DIFF
--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -83,10 +83,11 @@ const withNetworkConnectivity = ({
       }
 
       setupConnectivityCheckInterval(() => {
+        const { store } = this.context;
         let isConnected = this.state.isConnected;
         // When using redux integration, local state should match redux state.
-        if (withRedux && this.context.store) {
-          isConnected = this.context.store.getState().network.isConnected;
+        if (withRedux && store) {
+          isConnected = store.getState().network.isConnected;
         }
         if (isConnected && checkIntervalOfflineOnly) {
           return;

--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -85,7 +85,7 @@ const withNetworkConnectivity = ({
       setupConnectivityCheckInterval(() => {
         const { store } = this.context;
         let isConnected = this.state.isConnected;
-        // When using redux integration, local state should match redux state.
+        // When using redux integration, use store state for connection status
         if (withRedux && store) {
           isConnected = store.getState().network.isConnected;
         }

--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -83,7 +83,12 @@ const withNetworkConnectivity = ({
       }
 
       setupConnectivityCheckInterval(() => {
-        if (this.state.isConnected && checkIntervalOfflineOnly) {
+        let isConnected = this.state.isConnected;
+        // When using redux integration, local state should match redux state.
+        if (withRedux && this.context.store) {
+          isConnected = this.context.store.getState().network.isConnected;
+        }
+        if (isConnected && checkIntervalOfflineOnly) {
           return;
         }
         this.checkInternet();


### PR DESCRIPTION
### What this PR fixes
If using redux integration and option `checkIntervalOfflineOnly`. 
It will never make request to check internet connection. 
HOC `withNetworkConnectivity` has internal state, in which connection status is stored.
This however never gets updated. It's only set once during initialisation.

### Test scenario
> Make sure there is no internet connection

```js
withNetworkConnectivity({
  withRedux: true,
  checkConnectionInterval: 3000,
  checkIntervalOfflineOnly: true,
}),
```
Open app and check if there is any network request made to `google.com`. There will be no requests made. If we turn off option `checkIntervalOfflineOnly`, everything works fine.
With my change, it will always sync internal state with external redux state.
