### PR TITLE
Use new NetInfo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ This library supports React Native v0.55 or higher. You also need to have `react
 $ yarn add react-native-offline
 ```
 
+Once installed you need to link the `NetInfo` library and recompile
+```
+$ react-native link @react-native-community/netinfo
+```
+
 #### Android
 This library uses the `NetInfo` module from React Native Community underneath the hood. To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A comprehensive [example app](/example) is available within Expo to play with th
 ## Motivation
 When you are building your React Native app, you have to expect that some users may use your application in offline mode, for instance when travelling on a Plane (airplane mode) or the underground (no signal). How does your app behave in that situation? Does it show an infinite loader? Can the user still use it seamlessly?
 
-Having an offline first class citizen app is very important for a successful user experience. React Native ships with the `NetInfo` module in order to detect internet connectivity. The API is pretty basic and it may be sufficient for small apps but its usage gets cumbersome as your app grows. Besides that, it only detects network connectivity and does not guarantee internet access so it can provide false positives.
+Having an offline first class citizen app is very important for a successful user experience. React Native Community provides a `NetInfo` module in order to detect internet connectivity. The API is pretty basic and it may be sufficient for small apps but its usage gets cumbersome as your app grows. Besides that, it only detects network connectivity and does not guarantee internet access so it can provide false positives.
 
 This library aims to gather a variety of modules that follow React and Redux best practises, in order to make your life easier when it comes to deal with internet connectivity in your React Native application.
 
@@ -78,7 +78,7 @@ $ yarn add react-native-offline
 ```
 
 #### Android
-This library uses the `NetInfo` module from React Native underneath the hood. To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
+This library uses the `NetInfo` module from React Native Community underneath the hood. To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
 
 `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />`
 

--- a/docs_3x.md
+++ b/docs_3x.md
@@ -28,13 +28,8 @@ This library supports React Native v0.48 or higher.
 $ yarn add react-native-offline@3.15.2
 ```
 
-Once installed you need to link the `NetInfo` library and recompile
-```
-$ react-native link @react-native-community/netinfo
-```
-
 #### Android
-This library uses the `NetInfo` module from React Native Community underneath the hood. To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
+This library uses the `NetInfo` module from React Native underneath the hood. To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
 
   `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />`
 
@@ -435,8 +430,7 @@ The solution involves using some local state in your top most component and twea
 
 ```js
 // configureStore.js
-import { AsyncStorage, Platform } from 'react-native';
-import NetInfo from "@react-native-community/netinfo";
+import { AsyncStorage, Platform, NetInfo } from 'react-native';
 import { createStore, applyMiddleware, compose } from 'redux';
 import { persistStore, autoRehydrate } from 'redux-persist';
 import { createNetworkMiddleware, offlineActionTypes, checkInternetConnection } from 'react-native-offline';

--- a/docs_3x.md
+++ b/docs_3x.md
@@ -28,6 +28,11 @@ This library supports React Native v0.48 or higher.
 $ yarn add react-native-offline@3.15.2
 ```
 
+Once installed you need to link the `NetInfo` library and recompile
+```
+$ react-native link @react-native-community/netinfo
+```
+
 #### Android
 This library uses the `NetInfo` module from React Native Community underneath the hood. To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
 

--- a/docs_3x.md
+++ b/docs_3x.md
@@ -29,7 +29,7 @@ $ yarn add react-native-offline@3.15.2
 ```
 
 #### Android
-This library uses the `NetInfo` module from React Native underneath the hood. To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
+This library uses the `NetInfo` module from React Native Community underneath the hood. To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
 
   `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />`
 
@@ -430,7 +430,8 @@ The solution involves using some local state in your top most component and twea
 
 ```js
 // configureStore.js
-import { AsyncStorage, Platform, NetInfo } from 'react-native';
+import { AsyncStorage, Platform } from 'react-native';
+import NetInfo from "@react-native-community/netinfo";
 import { createStore, applyMiddleware, compose } from 'redux';
 import { persistStore, autoRehydrate } from 'redux-persist';
 import { createNetworkMiddleware, offlineActionTypes, checkInternetConnection } from 'react-native-offline';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-offline",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Handy toolbelt to deal with offline mode in React Native applications. Cross-platform, provides a smooth redux integration.",
   "main": "./src/index.js",
   "author": "Raul Gomez Acuña <raulgdeveloper@gmail.com> (https://github.com/rgommezz)",
@@ -69,6 +69,7 @@
     "redux-thunk": "^2.3.0"
   },
   "dependencies": {
+    "@react-native-community/netinfo": "^1.4.0",
     "lodash": "^4.17.11",
     "react-redux": "^6.0.0",
     "redux": "4.x",

--- a/src/components/NetworkConnectivity.js
+++ b/src/components/NetworkConnectivity.js
@@ -1,6 +1,7 @@
 /* @flow */
 import * as React from 'react';
-import { AppState, NetInfo, Platform } from 'react-native';
+import { AppState, Platform } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import type { HTTPMethod, State } from '../types';
 import * as connectivityInterval from '../utils/checkConnectivityInterval';
 import checkInternetAccess from '../utils/checkInternetAccess';

--- a/src/redux/sagas.js
+++ b/src/redux/sagas.js
@@ -2,7 +2,8 @@
 /* eslint flowtype/require-parameter-type: 0 */
 import { put, select, call, take, cancelled, fork } from 'redux-saga/effects';
 import { eventChannel } from 'redux-saga';
-import { AppState, NetInfo, Platform } from 'react-native';
+import { AppState, Platform } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import { networkSelector } from './reducer';
 import checkInternetAccess from '../utils/checkInternetAccess';
 import { connectionChange } from './actionCreators';

--- a/src/utils/checkInternetConnection.js
+++ b/src/utils/checkInternetConnection.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { NetInfo } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import checkInternetAccess from './checkInternetAccess';
 import { DEFAULT_PING_SERVER_URL, DEFAULT_TIMEOUT } from './constants';
 

--- a/test/checkInternetConnection.test.js
+++ b/test/checkInternetConnection.test.js
@@ -1,4 +1,4 @@
-import { NetInfo } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import checkInternetConnection from '../src/utils/checkInternetConnection';
 import checkInternetAccess from '../src/utils/checkInternetAccess';
 import {

--- a/test/sagaChannels.test.js
+++ b/test/sagaChannels.test.js
@@ -1,5 +1,5 @@
 import { eventChannel } from 'redux-saga';
-import { NetInfo } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import {
   createNetInfoConnectionChangeChannel,
   netInfoEventChannelFn,

--- a/test/sagas.test.js
+++ b/test/sagas.test.js
@@ -1,6 +1,7 @@
 /* @flow */
 import { testSaga } from 'redux-saga-test-plan';
-import { Platform, NetInfo, AppState } from 'react-native';
+import { Platform, AppState } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import networkSaga, {
   netInfoChangeSaga,
   connectionIntervalSaga,

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,6 +647,11 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@react-native-community/netinfo@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-1.4.0.tgz#8dd6de55ebf2792321fc392b9bd9144c4cedb9e3"
+  integrity sha512-5HDb7f4MhF8bF+K/5f0HdQtjU+8iujl9IFQHeRz1e4doWqtgWL4DhhfQqczchOI0xI/g8QT0ZZV4A6CayJt24Q==
+
 "@types/node@*":
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
@@ -6235,7 +6240,7 @@ redux-thunk@^2.3.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
-redux@^4.0.1:
+redux@4.x:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
   integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==


### PR DESCRIPTION
As of React Native 0.59, `NetInfo` has become deprecated (and shows warnings when using the latest RN) and will be removed in future versions.

This pull requests changes all `NetInfo` references to use https://github.com/react-native-community/react-native-netinfo instead.

Closes #172 