### PR TITLE
Can now have multplie thunks of same action type in queue

### DIFF
--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -30,12 +30,25 @@ function handleOfflineAction(
     const actionToLookUp = prevAction || prevThunk;
     const actionWithMetaData =
       typeof actionToLookUp === 'object'
-        ? { ...actionToLookUp, meta }
+        ? {
+            ...actionToLookUp,
+            meta,
+          }
         : actionToLookUp;
-    const similarActionQueued = getSimilarActionInQueue(
-      actionWithMetaData,
-      state.actionQueue,
-    );
+
+    const isActionUnique =
+      typeof prevAction === 'object' && get(meta, 'unique') === true;
+
+    const isThunkUnique =
+      typeof prevThunk === 'function' && get(prevThunk, 'meta.unique') === true;
+
+    let similarActionQueued;
+    if (isActionUnique || isThunkUnique) {
+      similarActionQueued = getSimilarActionInQueue(
+        actionWithMetaData,
+        state.actionQueue,
+      );
+    }
 
     return {
       ...state,


### PR DESCRIPTION
Fixes #163 

I am not sure what is the intent to remove the similar actions from the queue. I added a field `unique` in the meta data to enable this behavior.