### PR TITLE
Bug: add react-redux v7 as a compatible version to avoid loosing store in context

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.11",
-    "react-redux": "^6.0.0",
+    "react-redux": "^6.0.0 || ^7.0.0",
     "redux": "4.x",
     "redux-saga": "^1.0.2"
   },


### PR DESCRIPTION
`react-native-offline` is compatible only with react-redux v6 per its dependency list.

In case when the project uses `react-native-offline`, `react-redux` v7, `react-native-offline` loses store in context as it uses context from `react-native-offline/node_modules/react-redux` (v6) instead of ` the_project/node_modules/react-redux` (v7).

This PR just adjusts compatible version list of `react-redux`.

[React-redux](https://github.com/reduxjs/react-redux/releases) repository says that there shouldn't be any breaking changes.

> This release should be public-API-compatible with version 6. The only public breaking change is the update of our React peer dependency from 16.4 to 16.8.4.

Closes #184 