### PR TITLE
React-native-offline v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ protected List<ReactPackage> getPackages() {
     );
 }
 ```
-</details>                                                                    |
+
+</details>                                                                    
 
 ### RN >= 0.55 && RN <= 0.58
 Make sure to have `react-redux` version 6.x.x or 7.x.x installed.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
 
 Handful of utilities you should keep in your toolbelt to handle offline/online connectivity in React Native. It supports iOS, Android and Windows platforms. You can leverage all the functionalities provided or just the ones that suits your needs, the modules are conveniently decoupled.
 
-## Important (Please read)
-**This is the documentation for version 4.x.x. If you are migrating from v3 to v4, check the [release notes](https://github.com/rgommezz/react-native-offline/releases/tag/v4.0.0).**
-
 ## Example app
 A comprehensive [example app](/example) is available within Expo to play with the library and better understand its different modules. [Go and check it out!](https://exp.host/@rgommezz/react-native-offline-example)
 
@@ -72,13 +69,87 @@ This gives you the power to prioritize our work and support the project contribu
 [![issuehunt-image](https://camo.githubusercontent.com/f5f88939f6c627454b7c5d0eaef9f7cc40cc9586/68747470733a2f2f697373756568756e742e696f2f7374617469632f656d6265642f697373756568756e742d627574746f6e2d76312e737667)](https://issuehunt.io/repos/86369462)
 
 ## Installation
-This library supports React Native v0.55 or higher. You also need to have `react-redux` version 6.x.x installed.
+
+### RN >= 0.59x
+Make sure to have `react-redux` version 6.x.x or 7.x.x installed.
 ```
 $ yarn add react-native-offline
+
+# Or if you use npm
+$ npm i --save react-native-offline
+```
+
+This library uses `@react-native-community/netinfo@4.x.x` version underneath the hood. You then need to link the native parts of the library for the platforms you are using. If you are on React Native v0.60, you don't need to do anything else, since it supports autolinking. For iOS, just go to the `ios` folder and run `pod install`.
+
+Otherwise, the easiest way to link the library is using the CLI tool by running this command from the root of your project:
+
+```
+react-native link @react-native-community/netinfo
+```
+
+If you can't or don't want to use the CLI tool, you can also manually link the library using the instructions below (click on the arrow to show them):
+
+<details>
+<summary>Manually link the library on iOS</summary>
+
+Either follow the [instructions in the React Native documentation](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking) to manually link the framework or link using [Cocoapods](https://cocoapods.org) by adding this to your `Podfile`:
+
+```ruby
+pod 'react-native-netinfo', :path => '../node_modules/@react-native-community/netinfo'
+```
+
+</details>
+
+<details>
+<summary>Manually link the library on Android</summary>
+
+Make the following changes:
+
+#### `android/settings.gradle`
+```groovy
+include ':react-native-community-netinfo'
+project(':react-native-community-netinfo').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/netinfo/android')
+```
+
+#### `android/app/build.gradle`
+```groovy
+dependencies {
+   ...
+   implementation project(':react-native-community-netinfo')
+}
+```
+
+#### `android/app/src/main/.../MainApplication.java`
+On top, where imports are:
+
+```java
+import com.reactnativecommunity.netinfo.NetInfoPackage;
+```
+
+Add the `NetInfoPackage` class to your list of exported packages.
+
+```java
+@Override
+protected List<ReactPackage> getPackages() {
+    return Arrays.asList(
+            new MainReactPackage(),
+            new NetInfoPackage()
+    );
+}
+```
+</details>                                                                    |
+
+### RN >= 0.55 && RN <= 0.58
+Make sure to have `react-redux` version 6.x.x or 7.x.x installed.
+```
+$ yarn add react-native-offline@4.3.2
+
+# Or if you use npm
+$ npm i --save react-native-offline@4.3.2
 ```
 
 #### Android
-This library uses the `NetInfo` module from React Native underneath the hood. To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
+To request network info in Android an extra step is required, so you should add the following line to your app's `AndroidManifest.xml` as well:
 
 `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />`
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This gives you the power to prioritize our work and support the project contribu
 
 ## Installation
 
-### RN >= 0.59x
+### RN >= 0.59.x
 Make sure to have `react-redux` version 6.x.x or 7.x.x installed.
 ```
 $ yarn add react-native-offline
@@ -140,7 +140,7 @@ protected List<ReactPackage> getPackages() {
 
 </details>                                                                    
 
-### RN >= 0.55 && RN <= 0.58
+### RN >= 0.55.x && RN <= 0.58.x
 Make sure to have `react-redux` version 6.x.x or 7.x.x installed.
 ```
 $ yarn add react-native-offline@4.3.2

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ protected List<ReactPackage> getPackages() {
 }
 ```
 
-</details>                                                                    
+</details>
+
+Last but not list, you need to use [jetifier](https://github.com/mikehardy/jetifier) to convert the native dependency to AndroidX.
 
 ### RN >= 0.55.x && RN <= 0.58.x
 Make sure to have `react-redux` version 6.x.x or 7.x.x installed.

--- a/__mocks__/@react-native-community/netinfo.js
+++ b/__mocks__/@react-native-community/netinfo.js
@@ -1,0 +1,11 @@
+export default {
+  getCurrentConnectivity: jest.fn(),
+  isConnectionMetered: jest.fn(),
+  addListener: jest.fn(),
+  removeListeners: jest.fn(),
+  isConnected: {
+    fetch: jest.fn(() => Promise.resolve(true)),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-offline",
-  "version": "4.3.2",
+  "version": "5.0.0",
   "description": "Handy toolbelt to deal with offline mode in React Native applications. Cross-platform, provides a smooth redux integration.",
   "main": "./src/index.js",
   "author": "Raul Gomez Acuña <raulgdeveloper@gmail.com> (https://github.com/rgommezz)",
@@ -69,6 +69,7 @@
     "redux-thunk": "^2.3.0"
   },
   "dependencies": {
+    "@react-native-community/netinfo": "^4.1.2",
     "lodash": "^4.17.11",
     "react-redux": "^6.0.0 || ^7.0.0",
     "redux": "4.x",

--- a/src/components/NetworkConnectivity.js
+++ b/src/components/NetworkConnectivity.js
@@ -1,6 +1,7 @@
 /* @flow */
 import * as React from 'react';
-import { AppState, NetInfo, Platform } from 'react-native';
+import { AppState, Platform } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import type { HTTPMethod, State } from '../types';
 import * as connectivityInterval from '../utils/checkConnectivityInterval';
 import checkInternetAccess from '../utils/checkInternetAccess';

--- a/src/redux/sagas.js
+++ b/src/redux/sagas.js
@@ -2,7 +2,8 @@
 /* eslint flowtype/require-parameter-type: 0 */
 import { put, select, call, take, cancelled, fork } from 'redux-saga/effects';
 import { eventChannel } from 'redux-saga';
-import { AppState, NetInfo, Platform } from 'react-native';
+import { AppState, Platform } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import { networkSelector } from './reducer';
 import checkInternetAccess from '../utils/checkInternetAccess';
 import { connectionChange } from './actionCreators';

--- a/src/utils/checkInternetConnection.js
+++ b/src/utils/checkInternetConnection.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { NetInfo } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import checkInternetAccess from './checkInternetAccess';
 import { DEFAULT_PING_SERVER_URL, DEFAULT_TIMEOUT } from './constants';
 

--- a/test/checkInternetConnection.test.js
+++ b/test/checkInternetConnection.test.js
@@ -1,4 +1,4 @@
-import { NetInfo } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import checkInternetConnection from '../src/utils/checkInternetConnection';
 import checkInternetAccess from '../src/utils/checkInternetAccess';
 import {
@@ -16,9 +16,6 @@ describe('checkInternetConnection', () => {
   });
   describe('shouldPing = true', () => {
     it(`calls checkInternetAccess and resolves the promise with its returned value`, async () => {
-      NetInfo.isConnected.fetch.mockImplementationOnce(() =>
-        Promise.resolve(true),
-      );
       const isConnected = await checkInternetConnection('foo.com', 3000, true);
       expect(checkInternetAccess).toHaveBeenCalledWith({
         timeout: 3000,

--- a/test/sagaChannels.test.js
+++ b/test/sagaChannels.test.js
@@ -1,5 +1,5 @@
 import { eventChannel } from 'redux-saga';
-import { NetInfo } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import {
   createNetInfoConnectionChangeChannel,
   netInfoEventChannelFn,
@@ -8,7 +8,7 @@ import {
 } from '../src/redux/sagas';
 
 jest.mock('redux-saga');
-jest.mock('NetInfo');
+jest.mock('@react-native-community/netinfo');
 
 describe('createNetInfoConnectionChangeChannel', () => {
   it('returns a redux-saga channel', () => {

--- a/test/sagas.test.js
+++ b/test/sagas.test.js
@@ -1,6 +1,7 @@
 /* @flow */
 import { testSaga } from 'redux-saga-test-plan';
-import { Platform, NetInfo, AppState } from 'react-native';
+import { Platform, AppState } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import networkSaga, {
   netInfoChangeSaga,
   connectionIntervalSaga,

--- a/test/setupTestEnv.js
+++ b/test/setupTestEnv.js
@@ -1,8 +1,15 @@
 import React from 'react';
-import 'react-native';
+import { NativeModules } from 'react-native';
 import 'jest-enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Enzyme from 'enzyme';
+
+// Mocking the NetInfo native module
+NativeModules.RNCNetInfo = {
+  getCurrentState: jest.fn(),
+  addListener: jest.fn(),
+  removeListeners: jest.fn(),
+};
 
 /**
  * Set up DOM in node.js environment for Enzyme to mount to

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,12 +607,19 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.2.0":
+"@babel/runtime@^7.0.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
   integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
   dependencies:
     regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.4.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
 
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
@@ -646,6 +653,11 @@
     esutils "^2.0.2"
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
+
+"@react-native-community/netinfo@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-4.1.2.tgz#006c1c60e29918a47d3da786b28837b7aa15684f"
+  integrity sha512-3lW3Zv0V/Q14y5mNBa5ZcDfwTDZzivudPrQjY2awJFN8arw23AVe+dJual1VLny5fNXnWhaKPFHT6YYgs30k8w==
 
 "@redux-saga/core@^1.0.2":
   version "1.0.2"
@@ -3500,12 +3512,12 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
-  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
   dependencies:
-    react-is "^16.3.2"
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -5921,6 +5933,15 @@ prop-types@^15.5.8, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -6019,10 +6040,15 @@ react-dom@^16.6.3:
     prop-types "^15.6.2"
     scheduler "^0.12.0"
 
-react-is@^16.3.2, react-is@^16.6.1, react-is@^16.6.3, react-is@^16.7.0:
+react-is@^16.6.1, react-is@^16.7.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+
+react-is@^16.8.1, react-is@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-native-testing-library@^1.5.0:
   version "1.5.0"
@@ -6096,17 +6122,17 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-redux@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-6.0.0.tgz#09e86eeed5febb98e9442458ad2970c8f1a173ef"
-  integrity sha512-EmbC3uLl60pw2VqSSkj6HpZ6jTk12RMrwXMBdYtM6niq0MdEaRq9KYCwpJflkOZj349BLGQm1MI/JO1W96kLWQ==
+"react-redux@^6.0.0 || ^7.0.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.0.tgz#72af7cf490a74acdc516ea9c1dd80e25af9ea0b2"
+  integrity sha512-hyu/PoFK3vZgdLTg9ozbt7WF3GgX5+Yn3pZm5/96/o4UueXA+zj08aiSC9Mfj2WtD1bvpIb3C5yvskzZySzzaw==
   dependencies:
-    "@babel/runtime" "^7.2.0"
-    hoist-non-react-statics "^3.2.1"
+    "@babel/runtime" "^7.4.5"
+    hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
     loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-is "^16.6.3"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
 
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.6.3:
   version "16.7.0"
@@ -6274,6 +6300,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
Uses the newly separated `@react-native-community/netinfo` package, extracted from the core.

Fixes #172 