### PR TITLE
Implement custom user headers for HTTP request

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ type Props = {
     pingOnlyIfOffline?: boolean = false,
     pingInBackground?: boolean = false,
     httpMethod?: HTTPMethod = 'HEAD',
+    userHeaders?: {} = {},
 }
 ```
 
@@ -196,6 +197,8 @@ type Props = {
 `pingInBackground`: whether or not to check connectivity when app isn't in the foreground. Defaults to `false`.
 
 `httpMethod`: http method used to ping the server. Supports HEAD or OPTIONS. Defaults to `HEAD`.
+
+`userHeaders`: custom http headers to add to the request. Defaults to `{}`
 
 ##### Usage
 ```js

--- a/src/components/NetworkConnectivity.js
+++ b/src/components/NetworkConnectivity.js
@@ -9,6 +9,7 @@ import {
   DEFAULT_HTTP_METHOD,
   DEFAULT_TIMEOUT,
   DEFAULT_PING_SERVER_URL,
+  DEFAULT_USER_HEADERS,
 } from '../utils/constants';
 
 export type RequiredProps = {
@@ -24,6 +25,7 @@ export type DefaultProps = {
   pingOnlyIfOffline: boolean,
   pingInBackground: boolean,
   httpMethod: HTTPMethod,
+  userHeaders: {},
 };
 
 type Props = RequiredProps & DefaultProps;
@@ -67,6 +69,7 @@ class NetworkConnectivity extends React.PureComponent<Props, State> {
     pingOnlyIfOffline: false,
     pingInBackground: false,
     httpMethod: DEFAULT_HTTP_METHOD,
+    userHeaders: DEFAULT_USER_HEADERS,
   };
 
   constructor(props: Props) {
@@ -130,6 +133,7 @@ class NetworkConnectivity extends React.PureComponent<Props, State> {
       pingTimeout,
       pingServerUrl,
       httpMethod,
+      userHeaders,
     } = this.props;
     if (pingInBackground === false && AppState.currentState !== 'active') {
       return; // <-- Return early as we don't care about connectivity if app is not in foreground.
@@ -138,6 +142,7 @@ class NetworkConnectivity extends React.PureComponent<Props, State> {
       url: pingServerUrl,
       timeout: pingTimeout,
       method: httpMethod,
+      userHeaders,
     });
     this.handleConnectivityChange(hasInternetAccess);
   };

--- a/src/components/NetworkProvider.js
+++ b/src/components/NetworkProvider.js
@@ -22,6 +22,7 @@ type Props = {
   pingInBackground?: boolean,
   httpMethod?: HTTPMethod,
   children: React.Node,
+  userHeaders: {},
 };
 
 NetworkProvider.defaultProps = {

--- a/src/components/ReduxNetworkProvider.js
+++ b/src/components/ReduxNetworkProvider.js
@@ -21,6 +21,7 @@ type Props = {
   pingInBackground?: boolean,
   httpMethod?: HTTPMethod,
   children: React.Node,
+  userHeaders: {},
 };
 
 class ReduxNetworkProvider extends React.Component<Props> {

--- a/src/utils/checkInternetAccess.js
+++ b/src/utils/checkInternetAccess.js
@@ -5,18 +5,21 @@ import {
   DEFAULT_HTTP_METHOD,
   DEFAULT_PING_SERVER_URL,
   DEFAULT_TIMEOUT,
+  DEFAULT_USER_HEADERS,
 } from './constants';
 
 type Arguments = {
   url: string,
   timeout: number,
   method: HTTPMethod,
+  userHeaders: {},
 };
 
 export default function checkInternetAccess({
   timeout = DEFAULT_TIMEOUT,
   url = DEFAULT_PING_SERVER_URL,
   method = DEFAULT_HTTP_METHOD,
+  userHeaders = DEFAULT_USER_HEADERS,
 }: Arguments = {}): Promise<boolean> {
   return new Promise(async (resolve: (value: boolean) => void) => {
     try {
@@ -24,6 +27,7 @@ export default function checkInternetAccess({
         method,
         url,
         timeout,
+        userHeaders,
       });
       resolve(true);
     } catch (e) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,3 +2,4 @@
 export const DEFAULT_TIMEOUT = 10000;
 export const DEFAULT_PING_SERVER_URL = 'https://www.google.com/';
 export const DEFAULT_HTTP_METHOD = 'HEAD';
+export const DEFAULT_USER_HEADERS = {};

--- a/src/utils/makeHttpRequest.js
+++ b/src/utils/makeHttpRequest.js
@@ -17,6 +17,7 @@ type Options = {
     | 'onload/5xx'
     | 'onerror'
     | 'ontimeout',
+  customHeaders?: {},
 };
 
 type ResolvedValue = {
@@ -35,6 +36,7 @@ export const headers = {
  * @param url
  * @param timeout -> Timeout for rejecting the promise and aborting the API request
  * @param testMethod: for testing purposes
+ * @param customHeaders: headers received from user configuration.
  * @returns {Promise}
  */
 export default function makeHttpRequest({
@@ -42,6 +44,7 @@ export default function makeHttpRequest({
   url = DEFAULT_PING_SERVER_URL,
   timeout = DEFAULT_TIMEOUT,
   testMethod,
+  customHeaders = {},
 }: Options = {}) {
   return new Promise(
     (resolve: ResolvedValue => void, reject: ResolvedValue => void) => {
@@ -71,7 +74,7 @@ export default function makeHttpRequest({
           status: this.status,
         });
       };
-      Object.keys(headers).forEach((key: string) => {
+      Object.keys({ ...headers, ...customHeaders }).forEach((key: string) => {
         xhr.setRequestHeader(key, headers[key]);
       });
       xhr.send(null);

--- a/test/NetworkConnectivity.test.js
+++ b/test/NetworkConnectivity.test.js
@@ -255,6 +255,7 @@ describe('NetworkConnectivity', () => {
         pingServerUrl: 'dummy.com',
         httpMethod: 'OPTIONS',
         children: ChildrenComponent,
+        userHeaders: {},
       };
       AppState.currentState = 'active';
       const wrapper = shallow(
@@ -268,6 +269,7 @@ describe('NetworkConnectivity', () => {
         url: props.pingServerUrl,
         timeout: props.pingTimeout,
         method: props.httpMethod,
+        userHeaders: props.userHeaders,
       });
       expect(mockHandleConnectivityChange).toHaveBeenCalledWith(true);
     });

--- a/test/__snapshots__/NetworkConnectivity.test.js.snap
+++ b/test/__snapshots__/NetworkConnectivity.test.js.snap
@@ -10,5 +10,6 @@ Object {
   "pingServerUrl": "https://www.google.com/",
   "pingTimeout": 10000,
   "shouldPing": true,
+  "userHeaders": Object {},
 }
 `;

--- a/test/__snapshots__/NetworkProvider.test.js.snap
+++ b/test/__snapshots__/NetworkProvider.test.js.snap
@@ -10,6 +10,7 @@ exports[`NetworkProvider has the correct structure and default props 1`] = `
   pingServerUrl="https://www.google.com/"
   pingTimeout={10000}
   shouldPing={true}
+  userHeaders={Object {}}
 >
   [Function]
 </NetworkConnectivity>

--- a/test/__snapshots__/ReduxNetworkProvider.test.js.snap
+++ b/test/__snapshots__/ReduxNetworkProvider.test.js.snap
@@ -10,6 +10,7 @@ exports[`ReduxNetworkProvider render has the correct structure 1`] = `
   pingServerUrl="https://www.google.com/"
   pingTimeout={10000}
   shouldPing={true}
+  userHeaders={Object {}}
 >
   [Function]
 </NetworkConnectivity>

--- a/test/checkInternetAccess.test.js
+++ b/test/checkInternetAccess.test.js
@@ -4,6 +4,7 @@ import {
   DEFAULT_HTTP_METHOD,
   DEFAULT_PING_SERVER_URL,
   DEFAULT_TIMEOUT,
+  DEFAULT_USER_HEADERS,
 } from '../src/utils/constants';
 
 jest.mock('../src/utils/makeHttpRequest', () =>
@@ -22,6 +23,7 @@ describe('checkInternetAccess', () => {
       timeout: DEFAULT_TIMEOUT,
       url: DEFAULT_PING_SERVER_URL,
       method: DEFAULT_HTTP_METHOD,
+      userHeaders: DEFAULT_USER_HEADERS,
     });
   });
 
@@ -38,6 +40,7 @@ describe('checkInternetAccess', () => {
       url,
       timeout,
       method,
+      userHeaders: DEFAULT_USER_HEADERS,
     });
     expect(hasInternetAccess).toBe(true);
   });
@@ -55,6 +58,7 @@ describe('checkInternetAccess', () => {
       timeout,
       url,
       method,
+      userHeaders: DEFAULT_USER_HEADERS,
     });
     expect(hasInternetAccess).toBe(false);
   });

--- a/test/makeHttpRequest.test.js
+++ b/test/makeHttpRequest.test.js
@@ -71,6 +71,7 @@ describe('makeHttpRequest', () => {
     mockOpen.mockClear();
     mockSend.mockClear();
     mockSetTimeout.mockClear();
+    mockSetRequestHeader.mockClear();
     mockOnLoad.mockClear();
     mockOnError.mockClear();
     mockOnTimeout.mockClear();
@@ -106,6 +107,11 @@ describe('makeHttpRequest', () => {
       DEFAULT_PING_SERVER_URL,
     );
     expect(mockSetTimeout).toHaveBeenCalledWith(DEFAULT_TIMEOUT);
+  });
+
+  it('accepts custom headers', () => {
+    makeHttpRequest({ ...params, customHeaders: { foo: 'bar' } });
+    expect(mockSetRequestHeader).toHaveBeenCalledTimes(4);
   });
 
   describe('onload', () => {


### PR DESCRIPTION
## Motivation

Currently, there is no way to add custom user headers to the HTTP request. Both my team and community have encountered this issue (https://github.com/rgommezz/react-native-offline/issues/186). This PR enables the user to pass custom headers to the ping HTTP request

## Test plan

Code coverage is 100% after this PR.

Let me know if there's anything that can be improved :+1: