### PR TITLE
Fix config for persistStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ export default function configureStore(callback) {
   const store = createStore(rootReducer, applyMiddleware(networkMiddleware));
   const { connectionChange } = offlineActionCreators;
   // https://github.com/rt2zz/redux-persist#persiststorestore-config-callback
-  persistStore(store, { storage: AsyncStorage }, () => {
+  persistStore(store, null, () => {
     // After rehydration completes, we detect initial connection
     checkInternetConnection().then(isConnected => {
       store.dispatch(connectionChange(isConnected));


### PR DESCRIPTION
## Motivation

Example code was giving a wrong option for the config of `persistStore`.

Config there is of type `PersistStoreOptions`, which is:
```
export type PersistorOptions = {
  enhancer?: Function,
  manualPersist?: boolean
}
```
as seen in https://github.com/rt2zz/redux-persist/blob/master/src/types.js#L32-L35

## Test plan

None, this is a documentation only PR

## Code formatting

N/A, this is a documentation only PR