### PR TITLE
change: @react-native-community/netinfo docs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ yarn add react-native-offline
 $ npm i --save react-native-offline
 ```
 
-This library uses `@react-native-community/netinfo@4.x.x` version underneath the hood. You then need to link the native parts of the library for the platforms you are using.
+This library uses `@react-native-community/netinfo@5.x.x` version underneath the hood. You then need to link the native parts of the library for the platforms you are using.
 
 If you are on React Native v0.60, you don't need to do anything else, since it supports autolinking. For iOS, just go to the `ios` folder and run `pod install`. However, autolinking might not pick up and install the `@react-native-community/netinfo` dependency. If that happens, first install `@react-native-community/netinfo` directly, then run `pod install`, then install `react-native-offline` and finish with `pod install`.
 


### PR DESCRIPTION
With https://github.com/rgommezz/react-native-offline/pull/248, the netinfo version has changed to 5.3.x.
Bumping up the version mentioned here to keep the readme upto date.

Please provide enough information so that others can review your pull request:

## Motivation

I was confused by the errors that I got after running yarn. The react-native-offline version changed causing an error in manually linked project.