### PR TITLE
add: checkInternetConnection, configure method type

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,8 @@ Utility function that allows you to query for internet connectivity on demand. I
 checkInternetConnection(
   url?: string = 'https://www.google.com/',
   pingTimeout?: number = 10000,
-  shouldPing?: boolean = true
+  shouldPing?: boolean = true,
+  method?: HTTPMethod = 'HEAD'
 ): Promise<boolean>
 ```
 

--- a/src/utils/checkInternetConnection.ts
+++ b/src/utils/checkInternetConnection.ts
@@ -1,22 +1,33 @@
 import NetInfo from '@react-native-community/netinfo';
 import checkInternetAccess from './checkInternetAccess';
-import { DEFAULT_PING_SERVER_URL, DEFAULT_TIMEOUT } from './constants';
+import {
+  DEFAULT_PING_SERVER_URL,
+  DEFAULT_TIMEOUT,
+  DEFAULT_HTTP_METHOD,
+} from './constants';
+import { HTTPMethod } from '../types';
 
 /**
  * Utility that allows to query for internet connectivity on demand
  * @param url
  * @param timeout
  * @param shouldPing
+ * @param method
  * @returns {Promise<boolean>}
  */
 export default async function checkInternetConnection(
   url: string = DEFAULT_PING_SERVER_URL,
   timeout: number = DEFAULT_TIMEOUT,
   shouldPing = true,
+  method: HTTPMethod = DEFAULT_HTTP_METHOD,
 ): Promise<boolean> {
   return NetInfo.fetch().then(async connectionState => {
     if (shouldPing) {
-      const hasInternetAccess = await checkInternetAccess({ timeout, url });
+      const hasInternetAccess = await checkInternetAccess({
+        timeout,
+        url,
+        method,
+      });
       return hasInternetAccess;
     }
     return connectionState.isConnected;

--- a/test/checkInternetConnection.test.ts
+++ b/test/checkInternetConnection.test.ts
@@ -5,6 +5,7 @@ import checkInternetAccess from '../src/utils/checkInternetAccess';
 import {
   DEFAULT_PING_SERVER_URL,
   DEFAULT_TIMEOUT,
+  DEFAULT_HTTP_METHOD,
 } from '../src/utils/constants';
 
 jest.mock('../src/utils/checkInternetAccess');
@@ -21,6 +22,7 @@ describe('checkInternetConnection', () => {
     it(`calls checkInternetAccess and resolves the promise with its returned value`, async () => {
       const isConnected = await checkInternetConnection('foo.com', 3000, true);
       expect(checkInternetAccess).toHaveBeenCalledWith({
+        method: DEFAULT_HTTP_METHOD,
         timeout: 3000,
         url: 'foo.com',
       });
@@ -43,6 +45,7 @@ describe('checkInternetConnection', () => {
     fetch.mockImplementationOnce(() => Promise.resolve({ isConnected: true }));
     const isConnected = await checkInternetConnection();
     expect(checkInternetAccess).toHaveBeenCalledWith({
+      method: DEFAULT_HTTP_METHOD,
       timeout: DEFAULT_TIMEOUT,
       url: DEFAULT_PING_SERVER_URL,
     });


### PR DESCRIPTION
…nection

## Motivation

Fixes #263 

> When I try check my server availability as the first action (example from readme) using checkInternetConnection I can specify only url and timeout. But my server give status 200 only with OPTIONS method, with default HEAD it send 403. We can specify method for provider and context but can't for checkInternetConnection.

## Test plan

Test adapted to additional argument.

## Code formatting

Code was linted and prettiered (for `example` folder I reverted changes after prettier). 
