### PR TITLE
docs: fix the link to the async actions redux convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ type MiddlewareConfig = {
 This is the setup you need to put in place for libraries such as `redux-saga` or `redux-observable`, which rely on plain actions being dispatched to trigger async flow:
 
 `regexActionType`: regular expression to indicate the action types to be intercepted in offline mode.
-By default it's configured to intercept actions for fetching data following the Redux [convention](https://redux.js.org/docs/advanced/AsyncActions.html). That means that it will intercept actions with types such as `FETCH_USER_ID_REQUEST`, `FETCH_PRODUCTS_REQUEST` etc.
+By default it's configured to intercept actions for fetching data following the Redux [convention](https://redux.js.org/advanced/async-actions). That means that it will intercept actions with types such as `FETCH_USER_ID_REQUEST`, `FETCH_PRODUCTS_REQUEST` etc.
 
 `actionTypes`: array with additional action types to intercept that don't fulfil the RegExp criteria. For instance, it's useful for actions that carry along refreshing data, such as `REFRESH_LIST`.
 


### PR DESCRIPTION
The old link was broken.

## Motivation

The old link to the Redux docs was broken. I wanted to fix it so that future readers won't have to search the Redux docs to find the same information. 

## Test plan

I clicked on the link after updating it to make sure it goes to the correct section of the docs. 

## Code formatting

I just changed a few characters using GitHub's GUI so the formatting shouldn't have been altered. 
