### PR TITLE
docs: correct typo with `queue` naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ It works in the following way: if a `changeQueueSemaphore('RED')` action is disp
 ```js
 import { offlineActionCreators } from 'react-native-offline';
 ...
-async function weHaltQeueeReleaseHere(){
+async function weHaltQueueReleaseHere(){
   const { changeQueueSemaphore } = offlineActionCreators;
   dispatch(changeQueueSemaphore('RED')) // The queue is now halted and it won't continue dispatching actions
   await somePromise();


### PR DESCRIPTION
## Motivation

I use this lib and saw a small typo in Readme. Then, I decided to make the change!

Thanks for this great lib! 😄 

## Test plan

No test needed! Not a code change, just docs.
