### PR TITLE
Web support (#253)

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import pkg from './package.json';
 
 export default {
   input: 'src/index.ts',
-  external: ['react', 'react-native', 'redux', 'react-redux', 'redux-saga'],
+  external: ['react', 'react-native', 'redux', 'react-redux', 'redux-saga', '@react-native-community/netinfo],
   plugins: [resolve(), commonjs(), typescript()],
   output: [
     { file: pkg.main, format: 'cjs' },


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Issue #253 does not fully enable web support as the rollup build does packages up the native version of netinfo dependency, meaning downstream web apps will find it very difficult to use this module without build time code replacement.

By moving netinfo to an external module in rollup config, we can package this library without including it as a dependency. This will also allow users to decide the version of netinfo they use rather then having this libraries version included always.

This is unlikely to be a breaking change as you already recommend installing netinfo as a seperate dependency in your README, therefore, code should continue to work - but just fallback to teh netinfo version installed alongside this module.

## Test plan

Ive tested this on my local environment on web and native platforms. The library seems to still work.

The code must pass tests.

## Code formatting

No source code modified.