### PR TITLE
Add NetInfo connection type to ConnectivityState - fixes #224

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,11 +579,11 @@ import {
 } from 'react-native-offline';
 
 async function internetChecker(dispatch) {
-  const isConnected = await checkInternetConnection();
+  const { isConnected } = await checkInternetConnection();
   const { connectionChange } = offlineActionCreators;
   // Dispatching can be done inside a connected component, a thunk (where dispatch is injected), saga, or any sort of middleware
   // In this example we are using a thunk
-  dispatch(connectionChange(isConnected));
+  dispatch(connectionChange({ isConnected }));
 }
 ```
 
@@ -626,8 +626,8 @@ export default function configureStore(callback) {
   // https://github.com/rt2zz/redux-persist#persiststorestore-config-callback
   persistStore(store, null, () => {
     // After rehydration completes, we detect initial connection
-    checkInternetConnection().then(isConnected => {
-      store.dispatch(connectionChange(isConnected));
+    checkInternetConnection().then({ isConnected } => {
+      store.dispatch(connectionChange({ isConnected }));
       callback(); // Notify our root component we are good to go, so that we can render our app
     });
   });

--- a/src/components/NetworkConnectivity.tsx
+++ b/src/components/NetworkConnectivity.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { AppState, Platform } from 'react-native';
-import NetInfo, { NetInfoState } from '@react-native-community/netinfo';
+import NetInfo, {
+  NetInfoState,
+  NetInfoStateType,
+} from '@react-native-community/netinfo';
 import * as connectivityInterval from '../utils/checkConnectivityInterval';
 import checkInternetAccess from '../utils/checkInternetAccess';
 import { ConnectivityArgs, ConnectivityState } from '../types';
@@ -11,7 +14,7 @@ export type RequiredProps = {
 } & DefaultProps;
 
 export type DefaultProps = ConnectivityArgs & {
-  onConnectivityChange: (isConnected: boolean | null) => void;
+  onConnectivityChange: (state: ConnectivityState) => void;
 };
 
 function validateProps(props: RequiredProps) {
@@ -59,6 +62,7 @@ class NetworkConnectivity extends React.PureComponent<
     validateProps(props);
     this.state = {
       isConnected: null,
+      type: 'unknown' as NetInfoStateType.unknown,
     };
   }
 
@@ -79,12 +83,12 @@ class NetworkConnectivity extends React.PureComponent<
 
   componentDidUpdate(prevProps: RequiredProps, prevState: ConnectivityState) {
     const { pingServerUrl, onConnectivityChange } = this.props;
-    const { isConnected } = this.state;
+    const { isConnected, type } = this.state;
     if (prevProps.pingServerUrl !== pingServerUrl) {
       this.checkInternet();
     }
-    if (prevState.isConnected !== isConnected) {
-      onConnectivityChange(isConnected);
+    if (prevState.isConnected !== isConnected || prevState.type !== type) {
+      onConnectivityChange({ isConnected, type });
     }
   }
 
@@ -144,9 +148,10 @@ class NetworkConnectivity extends React.PureComponent<
     this.checkInternet();
   };
 
-  handleConnectivityChange = ({ isConnected }: NetInfoState) => {
+  handleConnectivityChange = ({ isConnected, type }: NetInfoState) => {
     this.setState({
       isConnected,
+      type,
     });
   };
 

--- a/src/components/ReduxNetworkProvider.tsx
+++ b/src/components/ReduxNetworkProvider.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
+import { NetInfoStateType } from '@react-native-community/netinfo';
 import NetworkConnectivity from './NetworkConnectivity';
 import { connectionChange } from '../redux/actionCreators';
 
-import { NetworkState, ConnectivityArgs } from '../types';
+import { NetworkState, ConnectivityArgs, ConnectivityState } from '../types';
 import { DEFAULT_ARGS } from '../utils/constants';
 
 interface AppState {
@@ -15,6 +16,7 @@ type OwnProps = ConnectivityArgs;
 
 interface StateProps {
   isConnected: boolean | null;
+  type?: NetInfoStateType;
   dispatch: Dispatch;
 }
 
@@ -25,10 +27,10 @@ type Props = OwnProps &
 class ReduxNetworkProvider extends React.Component<Props> {
   static defaultProps = DEFAULT_ARGS;
 
-  handleConnectivityChange = (isConnected: boolean | null) => {
-    const { isConnected: wasConnected, dispatch } = this.props;
-    if (isConnected !== wasConnected) {
-      dispatch(connectionChange(isConnected));
+  handleConnectivityChange = ({ isConnected, type }: ConnectivityState) => {
+    const { isConnected: wasConnected, type: prevType, dispatch } = this.props;
+    if (isConnected !== wasConnected || type !== prevType) {
+      dispatch(connectionChange({ isConnected, type }));
     }
   };
 
@@ -47,6 +49,7 @@ class ReduxNetworkProvider extends React.Component<Props> {
 
 const mapStateToProps = (state: AppState) => ({
   isConnected: state.network.isConnected,
+  type: state.network.type,
 });
 
 const ConnectedReduxNetworkProvider = connect(mapStateToProps)(

--- a/src/redux/actionCreators.ts
+++ b/src/redux/actionCreators.ts
@@ -1,9 +1,9 @@
 import * as actionTypes from './actionTypes';
-import { EnqueuedAction, SemaphoreColor } from '../types';
+import { ConnectivityState, EnqueuedAction, SemaphoreColor } from '../types';
 
-export const connectionChange = (isConnected: boolean | null) => ({
+export const connectionChange = ({ isConnected, type }: ConnectivityState) => ({
   type: actionTypes.CONNECTION_CHANGE as typeof actionTypes.CONNECTION_CHANGE,
-  payload: isConnected,
+  payload: { isConnected, type },
 });
 
 export const fetchOfflineMode = (action: EnqueuedAction) => {

--- a/src/redux/createReducer.ts
+++ b/src/redux/createReducer.ts
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 import without from 'lodash/without';
 import { AnyAction } from 'redux';
+import { NetInfoStateType } from '@react-native-community/netinfo';
 import * as actionTypes from './actionTypes';
 import { SEMAPHORE_COLOR } from '../utils/constants';
 import getSimilarActionInQueue from '../utils/getSimilarActionInQueue';
@@ -24,6 +25,7 @@ export const initialState = {
   isConnected: true,
   actionQueue,
   isQueuePaused: false,
+  type: 'unknown' as NetInfoStateType.unknown,
 };
 
 function handleOfflineAction(
@@ -109,7 +111,7 @@ export default (comparisonFn: ComparisonFn = getSimilarActionInQueue) => (
     case actionTypes.CONNECTION_CHANGE:
       return {
         ...state,
-        isConnected: action.payload,
+        ...action.payload,
       };
     case actionTypes.FETCH_OFFLINE_MODE:
       return handleOfflineAction(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { AnyAction } from 'redux';
+import { NetInfoStateType } from '@react-native-community/netinfo';
 
 export interface Thunk {
   (...args: any[]): any;
@@ -26,6 +27,7 @@ export interface NetworkState extends ConnectivityState {
 
 export type ConnectivityState = {
   isConnected: boolean | null;
+  type?: NetInfoStateType;
 };
 
 export type HTTPMethod = 'HEAD' | 'OPTIONS';

--- a/src/utils/checkInternetConnection.ts
+++ b/src/utils/checkInternetConnection.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_HTTP_METHOD,
   DEFAULT_CUSTOM_HEADERS,
 } from './constants';
-import { HTTPMethod, HTTPHeaders } from '../types';
+import { HTTPMethod, HTTPHeaders, ConnectivityState } from '../types';
 
 /**
  * Utility that allows to query for internet connectivity on demand
@@ -14,7 +14,7 @@ import { HTTPMethod, HTTPHeaders } from '../types';
  * @param timeout
  * @param shouldPing
  * @param method
- * @returns {Promise<boolean>}
+ * @returns {Promise<ConnectivityState>}
  */
 export default async function checkInternetConnection(
   url: string = DEFAULT_PING_SERVER_URL,
@@ -22,8 +22,8 @@ export default async function checkInternetConnection(
   shouldPing = true,
   method: HTTPMethod = DEFAULT_HTTP_METHOD,
   customHeaders: HTTPHeaders = DEFAULT_CUSTOM_HEADERS,
-): Promise<boolean | null> {
-  return NetInfo.fetch().then(async connectionState => {
+): Promise<ConnectivityState> {
+  return NetInfo.fetch().then(async ({ isConnected, type }) => {
     if (shouldPing) {
       const hasInternetAccess = await checkInternetAccess({
         timeout,
@@ -31,8 +31,8 @@ export default async function checkInternetConnection(
         method,
         customHeaders,
       });
-      return hasInternetAccess;
+      return { isConnected: hasInternetAccess, type };
     }
-    return connectionState.isConnected;
+    return { isConnected, type };
   });
 }

--- a/test/NetworkConnectivity.test.tsx
+++ b/test/NetworkConnectivity.test.tsx
@@ -88,12 +88,15 @@ describe('NetworkConnectivity', () => {
   it('passes the connection state into the FACC', () => {
     const children = jest.fn();
     shallow(getElement({ props: { children } }));
-    expect(children).toHaveBeenCalledWith({ isConnected: null });
+    expect(children).toHaveBeenCalledWith({
+      isConnected: null,
+      type: 'unknown' as NetInfoStateType.unknown,
+    });
   });
 
   describe('componentDidMount', () => {
     describe('iOS, pingInterval = 0', () => {
-      it(`sets up a NetInfo.isConnected listener for connectionChange 
+      it(`sets up a NetInfo.isConnected listener for connectionChange
       AND does NOT call setupConnectivityCheckInterval`, () => {
         Platform.OS = 'ios';
         const MockedNetworkConnectivity = mockPrototypeMethods({
@@ -264,7 +267,7 @@ describe('NetworkConnectivity', () => {
       expect(mockHandleConnectivityChange).not.toHaveBeenCalled();
     });
 
-    it(`calls checkInternetAccess AND handleConnectivityChange 
+    it(`calls checkInternetAccess AND handleConnectivityChange
     with the right arguments if app is in foreground`, async () => {
       const props = {
         pingTimeout: 2000,
@@ -350,7 +353,10 @@ describe('NetworkConnectivity', () => {
           isConnectionExpensive: false,
         },
       });
-      expect(mockSetState).toHaveBeenCalledWith({ isConnected: true });
+      expect(mockSetState).toHaveBeenCalledWith({
+        isConnected: true,
+        type: 'other' as NetInfoStateType.other,
+      });
 
       wrapper.instance().handleConnectivityChange({
         type: 'none' as NetInfoStateType.none,
@@ -358,7 +364,10 @@ describe('NetworkConnectivity', () => {
         isInternetReachable: false,
         details: null,
       });
-      expect(mockSetState).toHaveBeenCalledWith({ isConnected: false });
+      expect(mockSetState).toHaveBeenCalledWith({
+        isConnected: false,
+        type: 'none' as NetInfoStateType.none,
+      });
     });
   });
 

--- a/test/ReduxNetworkProvider.test.tsx
+++ b/test/ReduxNetworkProvider.test.tsx
@@ -5,6 +5,7 @@ import {
   render as rnRender,
 } from 'react-native-testing-library';
 import { shallow } from 'enzyme';
+import { NetInfoStateType } from '@react-native-community/netinfo';
 import {
   ReduxNetworkProvider,
   mapStateToProps,
@@ -53,19 +54,32 @@ describe('ReduxNetworkProvider', () => {
           <View />
         </ReduxNetworkProvider>,
       );
-      wrapper.instance().handleConnectivityChange(true);
-      expect(props.dispatch).toHaveBeenCalledWith(connectionChange(true));
+      wrapper.instance().handleConnectivityChange({
+        isConnected: true,
+        type: 'unknown' as NetInfoStateType.unknown,
+      });
+      expect(props.dispatch).toHaveBeenCalledWith(
+        connectionChange({
+          isConnected: true,
+          type: 'unknown' as NetInfoStateType.unknown,
+        }),
+      );
       expect(props.dispatch).toHaveBeenCalledTimes(1);
     });
 
     it(`does NOT dispatch a CONNECTION_CHANGE action if the connection
     did not change`, () => {
       const wrapper = shallow<ReduxNetworkProvider>(
-        <ReduxNetworkProvider {...getProps({ isConnected: true })}>
+        <ReduxNetworkProvider
+          {...getProps({ isConnected: true, type: 'unknown' })}
+        >
           <View />
         </ReduxNetworkProvider>,
       );
-      wrapper.instance().handleConnectivityChange(true);
+      wrapper.instance().handleConnectivityChange({
+        isConnected: true,
+        type: 'unknown' as NetInfoStateType.unknown,
+      });
       expect(props.dispatch).not.toHaveBeenCalled();
     });
   });
@@ -73,7 +87,10 @@ describe('ReduxNetworkProvider', () => {
 
 describe('mapStateToProps', () => {
   it('maps isConnected and actionQueue state to props', () => {
-    const expected = { isConnected: false };
+    const expected = {
+      isConnected: false,
+      type: 'unknown' as NetInfoStateType.unknown,
+    };
     const state = {
       network: {
         actionQueue: [],

--- a/test/checkInternetConnection.test.ts
+++ b/test/checkInternetConnection.test.ts
@@ -21,7 +21,14 @@ describe('checkInternetConnection', () => {
   });
   describe('shouldPing = true', () => {
     it(`calls checkInternetAccess and resolves the promise with its returned value`, async () => {
-      const isConnected = await checkInternetConnection('foo.com', 3000, true);
+      fetch.mockImplementationOnce(() =>
+        Promise.resolve({ isConnected: false }),
+      );
+      const { isConnected } = await checkInternetConnection(
+        'foo.com',
+        3000,
+        true,
+      );
       expect(checkInternetAccess).toHaveBeenCalledWith({
         method: DEFAULT_HTTP_METHOD,
         timeout: 3000,
@@ -37,7 +44,11 @@ describe('checkInternetConnection', () => {
       fetch.mockImplementationOnce(() =>
         Promise.resolve({ isConnected: false }),
       );
-      const isConnected = await checkInternetConnection('foo.com', 3000, false);
+      const { isConnected } = await checkInternetConnection(
+        'foo.com',
+        3000,
+        false,
+      );
       expect(checkInternetAccess).not.toHaveBeenCalled();
       expect(isConnected).toBe(false);
     });
@@ -45,7 +56,7 @@ describe('checkInternetConnection', () => {
 
   it('default parameters', async () => {
     fetch.mockImplementationOnce(() => Promise.resolve({ isConnected: true }));
-    const isConnected = await checkInternetConnection();
+    const { isConnected } = await checkInternetConnection();
     expect(checkInternetAccess).toHaveBeenCalledWith({
       method: DEFAULT_HTTP_METHOD,
       timeout: DEFAULT_TIMEOUT,

--- a/test/createNetworkMiddleware.test.ts
+++ b/test/createNetworkMiddleware.test.ts
@@ -96,9 +96,11 @@ describe('createNetworkMiddleware with actionTypes in config', () => {
       },
     };
     const store = mockStore(initialState);
-    store.dispatch(actionCreators.connectionChange(true));
+    store.dispatch(actionCreators.connectionChange({ isConnected: true }));
     const actions = store.getActions();
-    expect(actions).toEqual([actionCreators.connectionChange(true)]);
+    expect(actions).toEqual([
+      actionCreators.connectionChange({ isConnected: true }),
+    ]);
   });
 
   it('action ENQUEUED, queue PAUSED, status queue RESUMED', async () => {
@@ -184,7 +186,7 @@ describe('createNetworkMiddleware with different REGEX config', () => {
 describe('createNetworkMiddleware with thunks', () => {
   // Helper to simulate a network request
   const fetchMockData = (dispatch: Dispatch) =>
-    new Promise(resolve => {
+    new Promise<void>(resolve => {
       setTimeout(() => {
         dispatch({ type: 'FETCH_DATA_SUCCESS' });
         resolve();
@@ -503,7 +505,7 @@ describe('createReleaseQueue', () => {
 
   it('dispatches only during the online window', async () => {
     const switchToOffline = () =>
-      new Promise(async resolve => {
+      new Promise<void>(async resolve => {
         await wait(30);
         mockGetState.mockImplementation(() => ({
           network: {

--- a/test/reducer.test.ts
+++ b/test/reducer.test.ts
@@ -1,5 +1,6 @@
 import { Dispatch } from 'redux';
 import isEqual from 'lodash/isEqual';
+import { NetInfoStateType } from '@react-native-community/netinfo';
 import * as actionCreators from '../src/redux/actionCreators';
 import { EnqueuedAction, NetworkState } from '../src/types';
 import createReducer, {
@@ -14,6 +15,7 @@ const getState = (isConnected = false, ...actionQueue: EnqueuedAction[]) => ({
   isConnected,
   actionQueue,
   isQueuePaused: false,
+  type: 'unknown' as NetInfoStateType.unknown,
 });
 
 /** Actions used from now on to test different scenarios */
@@ -61,11 +63,15 @@ describe('unknown action type', () => {
 
 describe('CONNECTION_CHANGE action type', () => {
   it('changes isConnected state properly', () => {
-    const mockAction = actionCreators.connectionChange(false);
+    const mockAction = actionCreators.connectionChange({
+      isConnected: false,
+      type: 'unknown' as NetInfoStateType.unknown,
+    });
     expect(networkReducer(initialState, mockAction)).toEqual({
       isConnected: false,
       actionQueue: [],
       isQueuePaused: false,
+      type: 'unknown' as NetInfoStateType.unknown,
     });
   });
 });
@@ -100,7 +106,10 @@ describe('OFFLINE_ACTION action type', () => {
   describe('meta.retry === true', () => {
     describe('actions with DIFFERENT type', () => {
       it('actions are pushed into the queue in order of arrival', () => {
-        const preAction = actionCreators.connectionChange(false);
+        const preAction = actionCreators.connectionChange({
+          isConnected: false,
+          type: 'unknown' as NetInfoStateType.unknown,
+        });
         const action1 = actionCreators.fetchOfflineMode(prevActionToRetry1);
         const prevState = networkReducer(initialState, preAction);
 
@@ -110,6 +119,7 @@ describe('OFFLINE_ACTION action type', () => {
           isConnected: false,
           actionQueue: [prevActionToRetry1],
           isQueuePaused: false,
+          type: 'unknown' as NetInfoStateType.unknown,
         });
 
         const action2 = actionCreators.fetchOfflineMode(prevActionToRetry2);
@@ -286,7 +296,7 @@ describe('thunks', () => {
         );
       });
 
-      it(`should remove the thunk and add it back at the end of the queue 
+      it(`should remove the thunk and add it back at the end of the queue
       if it presents the same shape`, () => {
         const thunkFactory = (param: any) => {
           function thunk1(dispatch: Dispatch) {
@@ -400,12 +410,14 @@ describe('networkSelector', () => {
         isConnected: true,
         actionQueue: [{ type: 'foo', payload: {} }],
         isQueuePaused: false,
+        type: 'unknown' as NetInfoStateType.unknown,
       },
     };
     expect(networkSelector(state)).toEqual({
       isConnected: true,
       actionQueue: [{ type: 'foo', payload: {} }],
       isQueuePaused: false,
+      type: 'unknown' as NetInfoStateType.unknown,
     });
   });
 });


### PR DESCRIPTION
## Motivation

I came across #224 when I was looking for a way to expose the network type for analytics purposes.

## Test plan

Unit tests updated to pass. Tested in my app. The only problem I have is that when CONNECTION_CHANGE is dispatched the network type doesn't update immediately.

